### PR TITLE
Infinium v2.0.2 Release

### DIFF
--- a/src/Core/Currency.cpp
+++ b/src/Core/Currency.cpp
@@ -289,7 +289,7 @@ namespace
   }
 
 Amount Currency::get_base_block_reward(
-    uint8_t block_major_version, Height height, Amount already_generated_coins, Difficulty diff) const {
+    uint8_t block_major_version, Height height, AmountSupply already_generated_coins, Difficulty diff) const {
 	/*invariant(already_generated_coins <= money_supply, "");
 	invariant(emission_speed_factor > 0 && emission_speed_factor <= 8 * sizeof(Amount), "");
 
@@ -306,7 +306,7 @@ Amount Currency::get_base_block_reward(
 }
 
 Amount Currency::get_block_reward(uint8_t block_major_version, Height height, size_t effective_median_size,
-    size_t current_transactions_size, Amount already_generated_coins, Amount fee, SignedAmount *emission_change, Difficulty diff) const {
+    size_t current_transactions_size, AmountSupply already_generated_coins, Amount fee, SignedAmount *emission_change, Difficulty diff) const {
 	Amount base_reward = get_base_block_reward(block_major_version, height, already_generated_coins, diff);
 
 	Amount penalized_base_reward = get_penalized_amount(base_reward, effective_median_size, current_transactions_size);

--- a/src/Core/Currency.hpp
+++ b/src/Core/Currency.hpp
@@ -88,9 +88,9 @@ public:
 	PublicKey get_checkpoint_public_key(size_t key_id) const;
 	size_t get_checkpoint_keys_count() const { return checkpoint_keys_end - checkpoint_keys_begin; }
 
-	Amount get_base_block_reward(uint8_t block_major_version, Height height, Amount already_generated_coins, Difficulty diff) const;
+	Amount get_base_block_reward(uint8_t block_major_version, Height height, AmountSupply already_generated_coins, Difficulty diff) const;
 	Amount get_block_reward(uint8_t block_major_version, Height height, size_t effective_median_size,
-	    size_t current_transactions_size, Amount already_generated_coins, Amount fee,
+	    size_t current_transactions_size, AmountSupply already_generated_coins, Amount fee,
 	    SignedAmount *emission_change = nullptr, Difficulty diff=1000) const;
 	Transaction construct_miner_tx(const Hash &miner_secret, uint8_t block_major_version, Height height,
 	    Amount block_reward, const AccountAddress &miner_address) const;

--- a/src/CryptoNote.hpp
+++ b/src/CryptoNote.hpp
@@ -36,6 +36,9 @@ using namespace std::placeholders;  // We enjoy standard bindings
 typedef uint32_t Height;
 typedef uint64_t Difficulty;
 typedef uint64_t Amount;
+typedef __int128 int128_t;
+typedef unsigned __int128 uint128_t;
+typedef uint128_t AmountSupply;
 typedef uint32_t Timestamp;
 typedef uint64_t BlockOrTimestamp;
 // Height or Timestamp, 32-bit is enough, but historically we already have several very large values in blockchain

--- a/src/CryptoNote.hpp
+++ b/src/CryptoNote.hpp
@@ -36,9 +36,7 @@ using namespace std::placeholders;  // We enjoy standard bindings
 typedef uint32_t Height;
 typedef uint64_t Difficulty;
 typedef uint64_t Amount;
-typedef __int128 int128_t;
-typedef unsigned __int128 uint128_t;
-typedef uint128_t AmountSupply;
+typedef uint64_t AmountSupply;
 typedef uint32_t Timestamp;
 typedef uint64_t BlockOrTimestamp;
 // Height or Timestamp, 32-bit is enough, but historically we already have several very large values in blockchain

--- a/src/CryptoNoteConfig.hpp
+++ b/src/CryptoNoteConfig.hpp
@@ -193,7 +193,8 @@ constexpr const HardCheckpoint CHECKPOINTS[] = {
     {2065610, common::pfh<Hash>("94ab42d3c9c265c1e5923a31d667db02b36a18eb5f2310a58463c1814e7904e5")},
     {2065611, common::pfh<Hash>("c06f9f64d9b86ae6283ee747f9a49921235a1a144cbc42c5794d2128a1730546")},
     {2066800, common::pfh<Hash>("fe88ab36c46acf42cb24ad602b0dc3476cc2fb30390f9cbea751235b5991bc9e")},
-    {2066804, common::pfh<Hash>("0b7ac9b50c9413c2bc0e69fd67077436054a6481525a636b758456aa83c73878")}};
+    {2066804, common::pfh<Hash>("0b7ac9b50c9413c2bc0e69fd67077436054a6481525a636b758456aa83c73878")},
+    {2070700, common::pfh<Hash>("b645cd0e7f320c0552c5d0dfd7c670b39366616769d69ac580201156eda42d68")}};
 
 // When adding checkpoint and BEFORE release, you MUST check that daemon fully syncs both mainnet and stagenet.
 

--- a/src/CryptoNoteConfig.hpp
+++ b/src/CryptoNoteConfig.hpp
@@ -49,10 +49,11 @@ const Amount MONEY_SUPPLY            = std::numeric_limits<uint64_t>::max();
 const unsigned EMISSION_SPEED_FACTOR = 18;
 static_assert(EMISSION_SPEED_FACTOR <= 8 * sizeof(uint64_t), "Bad EMISSION_SPEED_FACTOR");
 
-const size_t DISPLAY_DECIMAL_POINT = 12;
-const Amount MIN_DUST_THRESHOLD    = 1000000;            // Everything smaller will be split in groups of 3 digits
-const Amount MAX_DUST_THRESHOLD    = 30000000000000000;  // Everything larger is dust because very few coins
-const Amount SELF_DUST_THRESHOLD   = 1000;               // forfeit outputs smaller than this in a change
+const size_t DISPLAY_DECIMAL_POINT    = 12;
+const Amount MIN_DUST_THRESHOLD       = 1000000;            // Everything smaller will be split in groups of 3 digits
+const Amount MAX_DUST_THRESHOLD       = 30000000000000000;  // Everything larger is dust because very few coins
+const Amount SELF_DUST_THRESHOLD      = 1000;               // forfeit outputs smaller than this in a change
+const Amount MAX_SUPPLY_RPC_DIVIDE_BY = 1000;               // divide already_generated_coins rpc response from get_block_header rpc command by this number
 
 const uint64_t ADDRESS_BASE58_PREFIX          = 1288825;       // legacy addresses start with "inf8"
 const uint64_t ADDRESS_BASE58_PREFIX_AMETHYST = 88386169;  // addresses start with "infi8"

--- a/src/rpc_api.cpp
+++ b/src/rpc_api.cpp
@@ -104,7 +104,7 @@ void ser_members(api::Output &v, ISeria &s, bool only_infiniumd_fields) {
 
 void ser_members(api::BlockHeader &v, ISeria &s) {
 	Amount total_supply_remove_decimals = cn::parameters::MAX_SUPPLY_RPC_DIVIDE_BY;
-	Amount total_supply_api (v.already_generated_coins/total_supply_remove_decimals);
+	Amount total_supply_api = (v.already_generated_coins/total_supply_remove_decimals);
 	seria_kv("major_version", v.major_version, s);
 	seria_kv("minor_version", v.minor_version, s);
 	seria_kv("timestamp", v.timestamp, s);

--- a/src/rpc_api.cpp
+++ b/src/rpc_api.cpp
@@ -6,6 +6,7 @@
 #include "Core/TransactionExtra.hpp"
 #include "common/Varint.hpp"
 #include "seria/JsonOutputStream.hpp"
+#include "CryptoNoteConfig.hpp"
 
 using namespace cn;
 
@@ -102,6 +103,8 @@ void ser_members(api::Output &v, ISeria &s, bool only_infiniumd_fields) {
 }
 
 void ser_members(api::BlockHeader &v, ISeria &s) {
+	Amount total_supply_remove_decimals = cn::parameters::MAX_SUPPLY_RPC_DIVIDE_BY;
+	Amount total_supply_api (v.already_generated_coins/total_supply_remove_decimals);
 	seria_kv("major_version", v.major_version, s);
 	seria_kv("minor_version", v.minor_version, s);
 	seria_kv("timestamp", v.timestamp, s);
@@ -125,7 +128,8 @@ void ser_members(api::BlockHeader &v, ISeria &s) {
 	seria_kv("base_reward", v.base_reward, s);
 	seria_kv("block_size", v.block_size, s);
 	seria_kv("transactions_size", v.transactions_size, s);
-	seria_kv("already_generated_coins", v.already_generated_coins, s);
+	seria_kv("already_generated_coins", total_supply_api, s);
+	seria_kv("already_generated_coins_multiply_by", total_supply_remove_decimals, s);
 	seria_kv("already_generated_transactions", v.already_generated_transactions, s);
 	seria_kv("already_generated_key_outputs", v.already_generated_key_outputs, s);
 	seria_kv("block_capacity_vote", v.block_capacity_vote, s);

--- a/src/rpc_api.cpp
+++ b/src/rpc_api.cpp
@@ -104,7 +104,6 @@ void ser_members(api::Output &v, ISeria &s, bool only_infiniumd_fields) {
 
 void ser_members(api::BlockHeader &v, ISeria &s) {
 	Amount total_supply_remove_decimals = cn::parameters::MAX_SUPPLY_RPC_DIVIDE_BY;
-	Amount total_supply_api = (v.already_generated_coins/total_supply_remove_decimals);
 	seria_kv("major_version", v.major_version, s);
 	seria_kv("minor_version", v.minor_version, s);
 	seria_kv("timestamp", v.timestamp, s);
@@ -128,7 +127,7 @@ void ser_members(api::BlockHeader &v, ISeria &s) {
 	seria_kv("base_reward", v.base_reward, s);
 	seria_kv("block_size", v.block_size, s);
 	seria_kv("transactions_size", v.transactions_size, s);
-	seria_kv("already_generated_coins", total_supply_api, s);
+	seria_kv("already_generated_coins", v.already_generated_coins, s);
 	seria_kv("already_generated_coins_multiply_by", total_supply_remove_decimals, s);
 	seria_kv("already_generated_transactions", v.already_generated_transactions, s);
 	seria_kv("already_generated_key_outputs", v.already_generated_key_outputs, s);

--- a/src/rpc_api.hpp
+++ b/src/rpc_api.hpp
@@ -112,7 +112,7 @@ struct BlockHeader {
 	size_t block_size        = 0;
 	size_t transactions_size = 0;
 
-	Amount already_generated_coins        = 0;
+	AmountSupply already_generated_coins        = 0;
 	size_t already_generated_transactions = 0;
 	size_t already_generated_key_outputs  = 0;
 	size_t size_median                    = 0;  // median of transactions_size, 0 in amethyst

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -5,7 +5,7 @@
 
 // defines are for Windows resource compiler
 #define infinium_VERSION_WINDOWS_COMMA 3, 19, 4, 18
-#define infinium_VERSION_STRING "v2.0.1 (New Chance)"
+#define infinium_VERSION_STRING "v2.0.2 (New Chance)"
 
 #ifndef RC_INVOKED  // Windows resource compiler
 


### PR DESCRIPTION
- fixed total supply calculation
- added checkpoint
- added "already_generated_coins_multiply_by" to response to "get_block_header" rpc command
- you can get current supply at current block by calling "get_block_header" and you can calculate from its response by multiplying response.result.block_header.already_generated_coins * response.result.block_header.already_generated_coins_multiply_by